### PR TITLE
Com.sun import bug

### DIFF
--- a/jboss-interceptor-core/src/main/java/org/jboss/interceptor/reader/InterceptorMetadataUtils.java
+++ b/jboss-interceptor-core/src/main/java/org/jboss/interceptor/reader/InterceptorMetadataUtils.java
@@ -11,7 +11,6 @@ import java.util.Set;
 
 import javax.interceptor.InvocationContext;
 
-import com.sun.source.tree.ModifiersTree;
 import org.jboss.interceptor.builder.MethodReference;
 import org.jboss.interceptor.spi.metadata.ClassMetadata;
 import org.jboss.interceptor.spi.metadata.InterceptorMetadata;


### PR DESCRIPTION
Hi Marius,

While building the jboss-interceptors project, i ran into a compile time error about the com.sun.\* import in one of the class. This patch includes that fix.

P.S: I see one another class which is using Sun implementation specific classes sun.\* ReflectionFactory. Is that intentional?

-Jaikiran
