### PR TITLE
The exception message should be clear about what's causing the problem...

### DIFF
--- a/src/main/java/org/jboss/interceptor/reader/InterceptorMetadataUtils.java
+++ b/src/main/java/org/jboss/interceptor/reader/InterceptorMetadataUtils.java
@@ -159,7 +159,7 @@ public class InterceptorMetadataUtils
                      }
                      if (detectedInterceptorTypes.contains(interceptionType))
                      {
-                        throw new InterceptorMetadataException("Same interception type cannot be specified twice on the same class");
+                        throw new InterceptorMetadataException("Same interception type (" + interceptionType.annotationClassName() + ") cannot be specified twice on the same class (" + interceptorClass.getJavaClass() + ")");
                      }
                      else
                      {


### PR DESCRIPTION
.... "There is a wrong class" is not enough, it should say "which class" is the problem.
